### PR TITLE
Update modification energy usage to match new default

### DIFF
--- a/config/Mekanism/machine-usage.toml
+++ b/config/Mekanism/machine-usage.toml
@@ -48,7 +48,7 @@
 	#Energy per operation tick (Joules).
 	formulaicAssemblicator = "100"
 	#Energy per operation tick (Joules).
-	modificationStation = "100"
+	modificationStation = "400"
 	#Energy per operation tick (Joules).
 	isotopicCentrifuge = "200"
 	#Energy per operation tick (Joules).


### PR DESCRIPTION
In the version of Mekanism I will upload shortly:tm: (so before launch) I adjusted the speed of the modification station and adjusted the default energy usage as well.