### PR TITLE
Update XyCraft core-server.toml

### DIFF
--- a/config/xycraft/core-server.toml
+++ b/config/xycraft/core-server.toml
@@ -1,4 +1,4 @@
 #Whether or not XyCraft uses neo or internal energy handling with items. The intended way is to use internal.
 #Allowed Values: Neo, Xynergy
-energy_paradigm = "Xynergy"
+energy_paradigm = "Neo"
 


### PR DESCRIPTION
Changes XyCraft to use Neo IEnergyStorage for now to allow the flare rod to be used.