### PR TITLE
Disable lootr compat with Bumblezone

### DIFF
--- a/config/the_bumblezone/mod_compatibility.toml
+++ b/config/the_bumblezone/mod_compatibility.toml
@@ -258,3 +258,13 @@
 		#
 		allowBeekeeperTradesCompat = true
 
+	["Mod Compatibility Options"."Lootr Options"]
+		# 
+		#-----------------------------------------------------
+		#
+		# Allow loot Cocoons to have compat with Lootr
+		#
+		allowLootrCompat = false
+
+
+


### PR DESCRIPTION
Bumblezone has been updated in the automated channel to a version with this config entry.

The Lootr compat should be disabled as there is a bug with Lootr on keep track of non 3 row inventories